### PR TITLE
handle null geometry in getGeometry()

### DIFF
--- a/R/esri2sf.R
+++ b/R/esri2sf.R
@@ -137,13 +137,12 @@ esri2sfPolygon <- function(features) {
   }
   getGeometry <- function(feature) {
     if(is.null(unlist(feature$geometry$rings))){
-      return(NULL)
+      return(sf::st_multipolygon())
     } else {
       return(rings2multipoly(feature$geometry$rings))
     }
   }
-  geoms_list <- lapply(features, getGeometry)
-  geoms <- sf::st_sfc(geoms_list[lengths(geoms_list)>0])
+  geoms <- sf::st_sfc(lapply(features, getGeometry))
   return(geoms)
 }
 


### PR DESCRIPTION
I was trying to use your excellent package on this [map server](https://inter-w01.dfo-mpo.gc.ca/arcgis/rest/services/CSSP_Base_Public/MapServer/1) and I kept getting errors because the old `getGeometry()` function could not handle null rings in the geometry. I also added a warning in `getEsriFeatures()` to avoid unhandled errors when there are no `ids` that match the search criteria.