### PR TITLE
httr:content always return json

### DIFF
--- a/R/esri2sf.R
+++ b/R/esri2sf.R
@@ -31,7 +31,8 @@ esri2sf <- function(url, outFields=c("*"), where="1=1", token='') {
         query=list(f="json", token=token),
         encode="form",
         config = httr::config(ssl_verifypeer = FALSE)
-        )
+        ),
+      as="text"
       )
     )
   print(layerInfo$type)
@@ -64,7 +65,8 @@ getObjectIds <- function(queryUrl, where, token=''){
       queryUrl,
       body=query,
       encode="form",
-      config = httr::config(ssl_verifypeer = FALSE))
+      config = httr::config(ssl_verifypeer = FALSE)),
+    as="text"
     )
   response <- jsonlite::fromJSON(responseRaw)
   return(response$objectIds)
@@ -85,7 +87,8 @@ getEsriFeaturesByIds <- function(ids, queryUrl, fields, token=''){
       body=query,
       encode="form",
       config = httr::config(ssl_verifypeer = FALSE)
-      )
+      ),
+    as="text"
     )
   response <- jsonlite::fromJSON(responseRaw,
                        simplifyDataFrame = FALSE,


### PR DESCRIPTION
This pull request fixes a bug that sometimes occurs because http:content is not always returning json which is then expected by jsonlite::fromJSON.

try
```{r}
devtools::install_github("yonghah/esri2sf")
x <- esri2sf(url = "http://gis.gcras.ru:6080/arcgis/rest/services/gisr/transportation/MapServer/1/")
```

then try it with my fixed version of your package:
```{r}
devtools::install_github("e-kotov/esri2sf")
x <- esri2sf(url = "http://gis.gcras.ru:6080/arcgis/rest/services/gisr/transportation/MapServer/1/")
```

I basically added `as = "text"` in `http:content` call in functions: `getObjectIds()`, `getEsriFeaturesByIds()` and `esri2sf()`.

Please kindly accept my fixes.