### PR TITLE
fix "Error: Argument 'txt' must be a JSON string, URL or file" for some links/servers

### DIFF
--- a/R/esri2sf.R
+++ b/R/esri2sf.R
@@ -31,7 +31,8 @@ esri2sf <- function(url, outFields=c("*"), where="1=1", token='') {
         query=list(f="json", token=token),
         encode="form",
         config = httr::config(ssl_verifypeer = FALSE)
-        )
+        ),
+      as="text"
       )
     )
   print(layerInfo$type)
@@ -68,7 +69,8 @@ getObjectIds <- function(queryUrl, where, token=''){
       queryUrl,
       body=query,
       encode="form",
-      config = httr::config(ssl_verifypeer = FALSE))
+      config = httr::config(ssl_verifypeer = FALSE)),
+    as="text"
     )
   response <- jsonlite::fromJSON(responseRaw)
   return(response$objectIds)
@@ -89,7 +91,8 @@ getEsriFeaturesByIds <- function(ids, queryUrl, fields, token=''){
       body=query,
       encode="form",
       config = httr::config(ssl_verifypeer = FALSE)
-      )
+      ),
+    as="text"
     )
   response <- jsonlite::fromJSON(responseRaw,
                        simplifyDataFrame = FALSE,

--- a/R/esri2sf.R
+++ b/R/esri2sf.R
@@ -31,7 +31,8 @@ esri2sf <- function(url, outFields=c("*"), where="1=1", token='') {
         query=list(f="json", token=token),
         encode="form",
         config = httr::config(ssl_verifypeer = FALSE)
-        )
+        ),
+      as = "text"
       )
     )
   print(layerInfo$type)
@@ -68,7 +69,8 @@ getObjectIds <- function(queryUrl, where, token=''){
       queryUrl,
       body=query,
       encode="form",
-      config = httr::config(ssl_verifypeer = FALSE))
+      config = httr::config(ssl_verifypeer = FALSE)),
+    as = "text"
     )
   response <- jsonlite::fromJSON(responseRaw)
   return(response$objectIds)
@@ -89,7 +91,8 @@ getEsriFeaturesByIds <- function(ids, queryUrl, fields, token=''){
       body=query,
       encode="form",
       config = httr::config(ssl_verifypeer = FALSE)
-      )
+      ),
+    as = "text"
     )
   response <- jsonlite::fromJSON(responseRaw,
                        simplifyDataFrame = FALSE,

--- a/R/esri2sf.R
+++ b/R/esri2sf.R
@@ -31,8 +31,7 @@ esri2sf <- function(url, outFields=c("*"), where="1=1", token='') {
         query=list(f="json", token=token),
         encode="form",
         config = httr::config(ssl_verifypeer = FALSE)
-        ),
-      as = "text"
+        )
       )
     )
   print(layerInfo$type)
@@ -69,8 +68,7 @@ getObjectIds <- function(queryUrl, where, token=''){
       queryUrl,
       body=query,
       encode="form",
-      config = httr::config(ssl_verifypeer = FALSE)),
-    as = "text"
+      config = httr::config(ssl_verifypeer = FALSE))
     )
   response <- jsonlite::fromJSON(responseRaw)
   return(response$objectIds)
@@ -91,8 +89,7 @@ getEsriFeaturesByIds <- function(ids, queryUrl, fields, token=''){
       body=query,
       encode="form",
       config = httr::config(ssl_verifypeer = FALSE)
-      ),
-    as = "text"
+      )
     )
   response <- jsonlite::fromJSON(responseRaw,
                        simplifyDataFrame = FALSE,


### PR DESCRIPTION
This pull request fixes a bug.  Internally some of your functions use `httr:content()` that is not reliably returning a json in plain text that is then passed on to `jsonlite::fromJSON()`, instead it sometimes returns a list.


try
```{r}
devtools::install_github("yonghah/esri2sf")
x <- esri2sf(url = "http://gis.gcras.ru:6080/arcgis/rest/services/gisr/transportation/MapServer/1/")
```

it returns:
`Error: Argument 'txt' must be a JSON string, URL or file.`

Here is the list that is for some reason returned from this link, which is why `jsonlite::fromJSON()` cannot handle it:
```{r}
outFields = c("*"); where = "1=1"; token = ""
url = "http://gis.gcras.ru:6080/arcgis/rest/services/gisr/transportation/MapServer/1/"
tmp_json <- httr::content(httr::POST(url, 
                                            query = list(f = "json", token = token), encode = "form", 
                                            config = httr::config(ssl_verifypeer = FALSE)))
class(tmp_json)
str(tmp_json, max.level = 1)
```

then try it with my fixed version of your package:
```{r}
devtools::install_github("e-kotov/esri2sf")
x <- esri2sf(url = "http://gis.gcras.ru:6080/arcgis/rest/services/gisr/transportation/MapServer/1/")
```

I basically added `as="text"` in `http:content()` call in functions: `getObjectIds()`, `getEsriFeaturesByIds()` and `esri2sf()`.

Please kindly accept my fixes.

p.s. this time it seems like the pull request is well made, last time I accidentally changed your EOL from LF to CRLF which is why the changes displayed like all lines were changed.