### PR TITLE
Add geomType optional input for rest endpoints lacking this information

### DIFF
--- a/man/esri2sf.Rd
+++ b/man/esri2sf.Rd
@@ -5,7 +5,7 @@
 \title{main function
 This function is the interface to the user.}
 \usage{
-esri2sf(url, outFields = c("*"), where = "1=1", token = "")
+esri2sf(url, outFields = c("*"), where = "1=1", token = "", geomType = NULL)
 }
 \arguments{
 \item{url}{string for service url. ex) \url{https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3}}
@@ -13,6 +13,8 @@ esri2sf(url, outFields = c("*"), where = "1=1", token = "")
 \item{outFields}{vector of fields you want to include. default is '*' for all fields}
 
 \item{where}{string for where condition. default is 1=1 for all rows}
+
+\item{geomType}{string specifying the layer geometry ('esriGeometryPolygon' or 'esriGeometryPoint' or 'esriGeometryPolyline' - if NULL, will try to be infered from the server)}
 
 \item{token.}{string for authentication token if needed.}
 }


### PR DESCRIPTION
I was trying to get information from an arcgis layer [(Coronavirus cases for the state of Rio de Janeiro)](https://services1.arcgis.com/OlP4dGNtIcnD3RYf/ArcGIS/rest/services/Casos_individuais_2/FeatureServer/0) that lacked geometry type information. 
I added an optional geomType parameter to the esri2sf function to be able to provide this information.
Do you think this would be a desirable feature?

By the way, thanks for this awesome package! 
