### PR TITLE
Return empty point if esri2sfPoint feature geometry contain NAs

### DIFF
--- a/R/esri2sf.R
+++ b/R/esri2sf.R
@@ -131,7 +131,11 @@ esri2sfGeom <- function(jsonFeats, geomType) {
 
 esri2sfPoint <- function(features) {
   getPointGeometry <- function(feature) {
-    return(sf::st_point(unlist(feature$geometry)))
+    if (is.numeric(unlist(feature$geometry))){
+      return(sf::st_point(unlist(feature$geometry)))
+    } else {
+      return(sf::st_point())
+    }
   }
   geoms <- sf::st_sfc(lapply(features, getPointGeometry))
   return(geoms)


### PR DESCRIPTION
If some coordinate values are non numeric, `esri2sf` produces an error.
For example, the following query fails, as some coordinates are non numeric - `list(x="NaN", y="NaN")` in this case.

```
url = "https://factmaps.npd.no/arcgis/rest/services/FactMaps/3_0/MapServer/201"
layer = esri2sf::esri2sf(url)
```

Returning an empty point 'st_point()' for these cases, circumvents this problem. Do you think this would be a desirable behaviour? It did solve my use case.
Thanks again, for this great library!