### PR TITLE
Added support for additional query parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,4 +17,4 @@ Imports:
     sf
 Suggests:
     knitr,
-RoxygenNote: 6.1.0
+RoxygenNote: 7.1.1

--- a/man/esri2sf.Rd
+++ b/man/esri2sf.Rd
@@ -5,7 +5,14 @@
 \title{main function
 This function is the interface to the user.}
 \usage{
-esri2sf(url, outFields = c("*"), where = "1=1", token = "", geomType = NULL)
+esri2sf(
+  url,
+  outFields = c("*"),
+  where = "1=1",
+  token = "",
+  geomType = NULL,
+  ...
+)
 }
 \arguments{
 \item{url}{string for service url. ex) \url{https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3}}
@@ -15,6 +22,8 @@ esri2sf(url, outFields = c("*"), where = "1=1", token = "", geomType = NULL)
 \item{where}{string for where condition. default is 1=1 for all rows}
 
 \item{geomType}{string specifying the layer geometry ('esriGeometryPolygon' or 'esriGeometryPoint' or 'esriGeometryPolyline' - if NULL, will try to be infered from the server)}
+
+\item{...}{additional named parameters to pass to the query. ex) "resultRecordCount = 3"}
 
 \item{token.}{string for authentication token if needed.}
 }


### PR DESCRIPTION
Added a `...` argument to `esri2sf()` to allow users to pass in additional named query parameters, increasing the flexibility for what can be done with the query.

Examples:
```
esri2sf(url = "https://services.arcgis.com/QVENGdaPbd4LUkLV/arcgis/rest/services/FWS_HQ_NWRS_Vegetation/FeatureServer/0",
        resultRecordCount = 3, 
        resultOffset = 1)

esri2sf(url = "https://services5.arcgis.com/54falWtcpty3V47Z/arcgis/rest/services/Bike_Master_Plan_Facilities/FeatureServer/1",
        geometry = "{'rings':[[[-121.503296,38.557831], [-121.503296,38.593261],  [-121.460724,38.593261],  [-121.460724,38.557831], [-121.503296,38.557831]]]}",
        geometryType = "esriGeometryPolygon",
        inSR = 4326,
        spatialRel = "esriSpatialRelContains")
```