### PR TITLE
Fix for #30

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -55,7 +55,7 @@ getObjectIds <- function(queryUrl, where, bbox, token = "", ...) {
   response$objectIds
 }
 
-getMaxRecordsCount <- function(queryUrl, token) {
+getMaxRecordsCount <- function(queryUrl, token, upperLimit = FALSE) {
 
   url <- sub("/query$", "", queryUrl)
 
@@ -65,9 +65,29 @@ getMaxRecordsCount <- function(queryUrl, token) {
                               config = config(ssl_verifypeer = FALSE)), as = "text")
   response <- fromJSON(responseRaw)
 
-  maxRC <- if (!is.null(response[['maxRecordCount']])) response[['maxRecordCount']] else 500L
+  if (!is.null(response[['maxRecordCount']])) {
+    if (response[['maxRecordCount']] > 25000 & upperLimit) {
+      maxRC <- 25000L
+    } else {
+      maxRC <- response[['maxRecordCount']]
+    }
+  } else {
+    maxRC <- 500L
+  }
 
   maxRC
+
+}
+
+getRecordsCount <- function(queryUrl, where, token = "", ...) {
+
+  query <- list(where = where, returnCountOnly = 'true', token = token, f = "json", ...)
+
+  responseRaw <- content(POST(queryUrl, body = query, encode = "form",
+                              config = config(ssl_verifypeer = FALSE)), as = "text")
+  response <- fromJSON(responseRaw)
+
+  response[['count']]
 
 }
 
@@ -90,6 +110,11 @@ getEsriFeaturesByIds <- function(ids, queryUrl, fields, token = "", crs = 4326, 
 
   response <- fromJSON(responseRaw, simplifyDataFrame = FALSE, simplifyVector = FALSE,
                        digits = NA)
+
+  if ('error' %in% names(response)) {
+    stop(paste0("Error code: ", response$error$code, ".\n  Message: ", response$error$message, "\n  Details: ", response$error$details))
+  }
+
   response$features
 }
 
@@ -131,7 +156,7 @@ getEsriFeatures <- function(queryUrl, fields, where, bbox, token = "", crs = 432
     warning("No records match the search criteria.")
     return()
   }
-  maxRC <- getMaxRecordsCount(queryUrl, token)
+  maxRC <- getMaxRecordsCount(queryUrl, token, upperLimit = TRUE)
   idSplits <- split(ids, seq_along(ids) %/% maxRC)
 
   if (is.null(crs)) {


### PR DESCRIPTION
This pull request addresses #30. Now you can run the following code and retrieve the features correctly:

```r
out <- esri2sf::esri2sf(url = 'https://services.arcgis.com/8ZpVMShClf8U8dae/arcgis/rest/services/TestingLocations_public2/FeatureServer/0', crs = NULL)
# Layer Type: Feature Layer
# Geometry Type: esriGeometryPoint
# Service Coordinate Reference System: 3857
out
# Simple feature collection with 42442 features and 50 fields (with 6 geometries empty)
# Geometry type: POINT
# Dimension:     XY
# Bounding box:  xmin: -19665430 ymin: -1611898 xmax: 16221950 ymax: 11505060
# Projected CRS: WGS 84 / Pseudo-Mercator
```