### PR TITLE
fix #36

### DIFF
--- a/R/esriUrl.R
+++ b/R/esriUrl.R
@@ -85,7 +85,7 @@ esriUrl_parseUrl <- function(url) {
 esriUrl_isValid <- function(url, displayReason = FALSE) {
   # check url succeeds
   urlError <- tryCatch({
-    httr::http_error(url)
+    httr::http_error(httr::GET(url))
   }, error = function(cond) {TRUE})
 
   if (!grepl("/rest/services", url)) {


### PR DESCRIPTION
Fix for issue #36. Changed `httr::http_error` to use a request instead of the URL as its input. Not really sure why this was needed as a URL or request object are both valid inputs to `httr::http_error`, but will add an issue to {httr}.  