### PR TITLE
fix: Correct `esri2df()` error by naming parameters and setting default bbox value

### DIFF
--- a/R/esri2sf.R
+++ b/R/esri2sf.R
@@ -115,7 +115,7 @@ esri2df <- function(url, outFields = c("*"), where = "1=1", token = "", progress
   if (layerInfo$type != "Table") stop("Layer type for URL is not 'Table'.")
 
   queryUrl <- paste(url, "query", sep = "/")
-  esriFeatures <- getEsriFeatures(queryUrl, outFields, where, token, progress, ...)
+  esriFeatures <- getEsriFeatures(queryUrl = queryUrl, fields = outFields, where = where, token = token, progress = progress, ...)
   df <- getEsriTable(esriFeatures)
   if (replaceDomainInfo) {
     df <- addDomainInfo(df, url = url, token = token)

--- a/R/testthat_helpers.R
+++ b/R/testthat_helpers.R
@@ -1,0 +1,7 @@
+skip_if_offline_url <- function(url) {
+  skip_if_offline()
+  if (!httr::http_error(httr::GET(url))) {
+    return(invisible(TRUE))
+  }
+  skip(paste0(url, " could not be resolved."))
+}

--- a/R/testthat_helpers.R
+++ b/R/testthat_helpers.R
@@ -1,8 +1,8 @@
 skip_if_offline_url <- function(url) {
-  skip_if_offline()
+  testthat::skip_if_offline()
   response <- httr::GET(url)
   if (!httr::http_error(response) & httr::content(response, as = 'text') != "") {
     return(invisible(TRUE))
   }
-  skip(paste0(url, " could not be resolved."))
+  testthat::skip(paste0(url, " could not be resolved."))
 }

--- a/R/testthat_helpers.R
+++ b/R/testthat_helpers.R
@@ -1,6 +1,7 @@
 skip_if_offline_url <- function(url) {
   skip_if_offline()
-  if (!httr::http_error(httr::GET(url))) {
+  response <- httr::GET(url)
+  if (!httr::http_error(response) & httr::content(response, as = 'text') != "") {
     return(invisible(TRUE))
   }
   skip(paste0(url, " could not be resolved."))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -33,13 +33,12 @@ generateOAuthToken <- function(clientId, clientSecret, expiration = 5000) {
 }
 
 
-getObjectIds <- function(queryUrl, where, bbox, token = "", ...) {
+getObjectIds <- function(queryUrl, where = "1=1", bbox = NULL, token = "", ...) {
 
   # create Simple Features from ArcGIS servers json response
   query <- list(where = where, geometryType = "esriGeometryEnvelope",
                 geometry = bbox, returnIdsOnly = "true", token = token,
                 f = "json", ...)
-
   responseRaw <- httr::content(httr::POST(queryUrl, body = query, encode = "form",
                               config = httr::config(ssl_verifypeer = FALSE)), as = "text")
 
@@ -47,7 +46,7 @@ getObjectIds <- function(queryUrl, where, bbox, token = "", ...) {
   response$objectIds
 }
 
-getMaxRecordsCount <- function(queryUrl, token, upperLimit = FALSE) {
+getMaxRecordsCount <- function(queryUrl, token = "", upperLimit = FALSE) {
 
   url <- sub("/query$", "", queryUrl)
 
@@ -71,7 +70,7 @@ getMaxRecordsCount <- function(queryUrl, token, upperLimit = FALSE) {
 
 }
 
-getRecordsCount <- function(queryUrl, where, token = "", ...) {
+getRecordsCount <- function(queryUrl, where = "1=1", token = "", ...) {
 
   query <- list(where = where, returnCountOnly = 'true', token = token, f = "json", ...)
 
@@ -91,7 +90,7 @@ getEsriTable <- function(jsonFeats) {
 }
 
 
-getEsriFeaturesByIds <- function(ids, queryUrl, fields, token = "", crs = 4326, ...) {
+getEsriFeaturesByIds <- function(ids, queryUrl, fields = c("*"), token = "", crs = 4326, ...) {
   # create Simple Features from ArcGIS servers json response
   query <- list(objectIds = paste(ids, collapse = ","),
                 outFields = paste(fields, collapse = ","),
@@ -142,7 +141,7 @@ esri2sfPolyline <- function(features) {
   sf::st_sfc(lapply(features, getGeometry))
 }
 
-getEsriFeatures <- function(queryUrl, fields, where, bbox = NULL, token = "", crs = 4326, progress = FALSE, ...) {
+getEsriFeatures <- function(queryUrl, fields = c("*"), where = "1=1", bbox = NULL, token = "", crs = 4326, progress = FALSE, ...) {
   ids <- getObjectIds(queryUrl, where, bbox, token, ...)
   if (is.null(ids)) {
     warning("No records match the search criteria.")

--- a/tests/testthat/_snaps/esri2df.md
+++ b/tests/testthat/_snaps/esri2df.md
@@ -1,0 +1,34 @@
+# esri2df returns expected values [1]
+
+    Code
+      esri2df(url = url, objectIds = paste(1:10, collapse = ","))
+    Message <simpleMessage>
+      Layer Type: Table
+    Output
+      # A tibble: 10 x 6
+         OBJECTID FACILITYID FCLASS ASSETCOND CONDDATE REPLSCORE
+            <int> <chr>      <chr>  <lgl>     <lgl>        <int>
+       1        1 1          wMain  NA        NA               0
+       2        2 2          wMain  NA        NA              45
+       3        3 3          wMain  NA        NA              45
+       4        4 4          wMain  NA        NA              45
+       5        5 5          wMain  NA        NA              15
+       6        6 6          wMain  NA        NA              15
+       7        7 1          wMain  NA        NA               0
+       8        8 2          wMain  NA        NA              45
+       9        9 3          wMain  NA        NA              45
+      10       10 4          wMain  NA        NA              45
+
+---
+
+    Code
+      esri2df(url = url, where = "OBJECTID <= 10 AND FACILITYID = '4'")
+    Message <simpleMessage>
+      Layer Type: Table
+    Output
+      # A tibble: 2 x 6
+        OBJECTID FACILITYID FCLASS ASSETCOND CONDDATE REPLSCORE
+           <int> <chr>      <chr>  <lgl>     <lgl>        <int>
+      1        4 4          wMain  NA        NA              45
+      2       10 4          wMain  NA        NA              45
+

--- a/tests/testthat/test-esri2df.R
+++ b/tests/testthat/test-esri2df.R
@@ -1,0 +1,17 @@
+
+test_that("esri2df returns expected values [1]", {
+  url <- 'https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/WaterTemplate/WaterDistributionInventoryReport/MapServer/5'
+  skip_if_offline_url(url)
+  expect_snapshot(esri2df(url = url,
+                          objectIds = paste(1:10, collapse = ",")))
+  expect_snapshot(esri2df(url = url,
+                          where = "OBJECTID <= 10 AND FACILITYID = '4'"))
+})
+
+
+test_that("esri2df returns expected values [2]", {
+  url <- 'https://opendata.baltimorecity.gov/egis/rest/services/Hosted/311_Customer_Service_Requests_2020_csv/FeatureServer/0'
+  skip_if_offline_url(url)
+  expect_true(nrow(esri2df(url = url, where = "agency = 'Health' AND srstatus = 'New'")) > 1)
+})
+

--- a/tests/testthat/test-esriUrl.R
+++ b/tests/testthat/test-esriUrl.R
@@ -1,4 +1,6 @@
 test_that("esriUrl_ServerUrl returns correct substring", {
+  skip_if_offline_url(url = "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3")
+
   expect_identical(esriUrl_ServerUrl("https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3"), "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer")
   expect_identical(esriUrl_ServerUrl("https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer"), "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer")
   expect_identical(esriUrl_ServerUrl("https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/"), "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer")
@@ -6,6 +8,8 @@ test_that("esriUrl_ServerUrl returns correct substring", {
 })
 
 test_that("esriUrl_isValid checks", {
+  skip_if_offline_url(url = "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3")
+
   expect_true(esriUrl_isValid("https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3"))
   expect_true(esriUrl_isValid("https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer"))
 
@@ -27,6 +31,8 @@ test_that("esriUrl_isValid checks", {
 
 
 test_that("esriUrl_isValidID checks", {
+  skip_if_offline_url(url = "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3")
+
   expect_true(esriUrl_isValidID("https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3"))
 
   expect_false(esriUrl_isValidID("https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/"))
@@ -36,6 +42,8 @@ test_that("esriUrl_isValidID checks", {
 
 
 test_that("esriUrl_isValidService checks", {
+  skip_if_offline_url(url = "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3")
+
   expect_true(esriUrl_isValidService("https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer"))
 
   expect_false(esriUrl_isValidService("https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/"))
@@ -45,6 +53,9 @@ test_that("esriUrl_isValidService checks", {
 })
 
 test_that("esriUrl_parseUrl", {
+  skip_if_offline_url(url = "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3")
+  skip_if_offline_url(url = "https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Landscape_Trees/FeatureServer/0")
+
   expect_snapshot(esriUrl_parseUrl('https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer/3'))
   expect_snapshot(esriUrl_parseUrl('https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Census_USA/MapServer'))
   expect_snapshot(esriUrl_parseUrl('https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Landscape_Trees/FeatureServer/0'))


### PR DESCRIPTION
I kept running into an issue with `esri2df()` not returning any features. I fixed the issue by setting the default value of `bbox` to NULL and naming the parameters for `getEsriFeatures()` when it is called within `esri2df()`. I'm not certain why this works but it does.